### PR TITLE
Added ability to add site key after plugin has been setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,31 @@
 # Vue reCAPTCHA-v3
+
 [![npm](https://img.shields.io/npm/v/vue-recaptcha-v3.svg)](https://www.npmjs.com/package/vue-recaptcha-v3)
 [![npm type definitions](https://img.shields.io/npm/types/vue-recaptcha-v3.svg)](https://www.npmjs.com/package/vue-recaptcha-v3)
 
 A simple and easy to use reCAPTCHA (v3 only) library for Vue based on [reCAPTCHA-v3](https://github.com/AurityLab/recaptcha-v3).
 
 ## Install
+
 With NPM:
+
 ```bash
-$ npm install vue-recaptcha-v3
+npm install vue-recaptcha-v3
 ```
 
 With Yarn:
+
 ```bash
-$ yarn add vue-recaptcha-v3
+yarn add vue-recaptcha-v3
 ```
- 
+
 ## Prerequisites
+
 To use this package you only need a valid site key for your domain, which you can easily get [here](https://www.google.com/recaptcha).
 
 ## Usage
+
+### Load with the sitekey at initialization
 
 ```javascript
 import Vue from 'vue'
@@ -43,18 +50,59 @@ new Vue({
 })
 ```
 
+### Load ReCaptcha after the plugin has been initialized
+
+```javascript
+import Vue from 'vue'
+import { VueReCaptcha } from 'vue-recaptcha-v3'
+const axios = require('axios')
+
+// Primes the plugin with other values besides the site key
+Vue.use(VueReCaptcha, {
+  loaderOptions: {
+    useRecaptchaNet: true
+  }
+})
+new Vue({
+  methods: {
+    async recaptcha() {
+
+    // example of a web call to get the siteKey from an api, this is not a real web call
+    axios.get('/SiteKey')
+      .then(function (response) {
+        let siteKey = response.data.siteKey
+        //Loads the recaptcha with the key from the api
+        this.$loadRecaptchaAfterSetup('<site key>')
+      });
+
+      // Waits until this.$loadRecaptchaAfterSetup is called and sets up the captcha with the site key from the api
+      await this.$recaptchaLoaded()
+
+      // Execute reCAPTCHA with action "login".
+      const token = await this.$recaptcha('login')
+
+      // Do stuff with the received token.
+    }
+  },
+  template: '<button @click="recaptcha">Execute recaptcha</button>'
+})
+```
+
 ## Options
+
 This plugin offers optional options to configure the behavior of some parts.
 
 Available options:
 
-|Name|Description|Type|Default value
-|----|-----------|----|-------------
-|siteKey|The site key for your domain from Google.|*string*|*none*
-|loaderOptions|Optional options for the [recaptcha-v3](https://github.com/AurityLab/recaptcha-v3) loader. The available options are described [here](https://github.com/AurityLab/recaptcha-v3/#load-options-usage).|*object*|`null`
+| Name          | Description                                                                                                                                                                                           | Type     | Default value |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ------------- |
+| siteKey       | The site key for your domain from Google.                                                                                                                                                             | *string* | *none*        |
+| loaderOptions | Optional options for the [recaptcha-v3](https://github.com/AurityLab/recaptcha-v3) loader. The available options are described [here](https://github.com/AurityLab/recaptcha-v3/#load-options-usage). | *object* | `null`        |
 
 ### Usage
+
 To use the options just pass an object to the `Vue.use(...)` method. For example:
+
 ```javascript
 import Vue from 'vue'
 import { VueReCaptcha } from 'vue-recaptcha-v3'
@@ -68,10 +116,13 @@ Vue.use(VueReCaptcha, {
 ```
 
 ## Advanced usage
+
 Some topics which are not commonly used, but required in some cases.
 
 ### Access [reCAPTCHA-v3](https://github.com/AurityLab/recaptcha-v3/#load-options-usage) instance
-In some cases it's necessary to interact with the reCAPTCHA-v3 instance, which provides more control over reCAPTCHA. 
+
+In some cases it's necessary to interact with the reCAPTCHA-v3 instance, which provides more control over reCAPTCHA.
+
 ```javascript
 const recaptcha = this.$recaptchaInstance
 

--- a/demo/src/delaydemo.ts
+++ b/demo/src/delaydemo.ts
@@ -1,19 +1,25 @@
 import Vue from 'vue'
 import { VueReCaptcha } from '../../src/ReCaptchaVuePlugin'
 
-Vue.use(VueReCaptcha, { siteKey: '6LfC6HgUAAAAAEtG92bYRzwYkczElxq7WkCoG4Ob' })
+Vue.use(VueReCaptcha, { })
 
 new Vue({
   methods: {
-    recaptcha () {
+    async recaptcha () {
       console.log('recaptcha clicked')
+
       this.$recaptchaLoaded().then(() => {
         console.log('recaptcha loaded')
         this.$recaptcha('login').then((token: string) => {
           console.log(token) // Will print the token
         })
       })
+      await this.delay(1000)
+      this.$loadRecaptchaAfterSetup('6LfC6HgUAAAAAEtG92bYRzwYkczElxq7WkCoG4Ob')
+    },
+    async delay (ms: number) {
+      return new Promise(resolve => setTimeout(resolve, ms))
     }
   },
-  template: '<button @click="recaptcha">Execute without delay recaptcha</button>'
-}).$mount('#inject')
+  template: '<button @click="recaptcha">Execute with delay recaptcha</button>'
+}).$mount('#delaydemo')

--- a/demo/src/index.html
+++ b/demo/src/index.html
@@ -7,5 +7,8 @@
 </head>
 <body>
 <div id="inject"></div>
+<br>
+<br>
+<div id="delaydemo"></div>
 </body>
 </html>

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -3,8 +3,11 @@ const webpack = require('webpack')
 const WebpackHtmlPlugin = require('html-webpack-plugin')
 
 module.exports = {
-  entry: path.resolve(__dirname, './src/index.ts'),
-
+  watch: true,
+  entry: {
+    index: path.resolve(__dirname, './src/index.ts'),
+    delaydemo: path.resolve(__dirname, './src/delaydemo.ts')
+  },
   output: {
     path: path.resolve(__dirname, './dist'),
     publicPath: '/'
@@ -24,13 +27,13 @@ module.exports = {
   resolve: {
     extensions: [
       '.js',
-      '.ts',
+      '.ts'
     ],
     alias: {
-      'vue$': 'vue/dist/vue.esm.js'
+      vue$: 'vue/dist/vue.esm.js'
     }
   },
-  mode: "development",
+  mode: 'development',
   devServer: {
     compress: true,
     disableHostCheck: true,
@@ -39,7 +42,7 @@ module.exports = {
   plugins: [
     new WebpackHtmlPlugin({
       template: path.resolve(__dirname, './src/index.html'),
-      inject: true,
+      inject: true
     })
-  ],
-};
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "demo:webpack:server": "webpack-dev-server --config demo/webpack.config.js --progress --public --host 0.0.0.0"
   },
   "dependencies": {
-    "recaptcha-v3": "^1.8.0"
+    "recaptcha-v3": "^1.8.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "2",

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -20,18 +20,37 @@ export function VueReCaptcha (Vue: typeof _Vue, options: IReCaptchaOptions): voi
     loadedWaiters.push({ resolve, reject })
   })
 
-  plugin.initializeReCaptcha(options).then((wrapper) => {
+  const thenAction: any = (wrapper: ReCaptchaInstance) => {
     recaptchaLoaded = true
     Vue.prototype.$recaptcha = async (action: string): Promise<string> => {
       return wrapper.execute(action)
     }
-
     Vue.prototype.$recaptchaInstance = wrapper
     loadedWaiters.forEach((v) => v.resolve(true))
-  }).catch((error) => {
+  }
+
+  const catchAction: any = (error: any) => {
     recaptchaError = error
     loadedWaiters.forEach((v) => v.reject(error))
-  })
+  }
+  if (options.siteKey != null) {
+    plugin.initializeReCaptcha(options).then((wrapper) => {
+      thenAction(wrapper)
+    }).catch((error) => {
+      catchAction(error)
+    })
+  } else {
+    Vue.prototype.$captchaOptions = options
+    Vue.prototype.$loadRecaptchaAfterSetup = async (siteKey: string): Promise<any> => {
+      const options = Vue.prototype.$captchaOptions
+      options.siteKey = siteKey
+      await plugin.initializeReCaptcha(options).then((wrapper) => {
+        thenAction(wrapper)
+      }).catch((error) => {
+        catchAction(error)
+      })
+    }
+  }
 }
 
 class ReCaptchaVuePlugin {
@@ -45,5 +64,6 @@ declare module 'vue/types/vue' {
     $recaptcha(action: string): Promise<string>
     $recaptchaLoaded(): Promise<boolean>
     $recaptchaInstance: ReCaptchaInstance
+    $loadRecaptchaAfterSetup(siteKey: string): Promise<any>
   }
 }


### PR DESCRIPTION
Using this inside of one of my projects and it has made adding repcatcha to a vue project painless. I came across the need to have to add the Site Key added after initialization. So i made the changes to work with my project. Cleaned it up and wanted to do a pr! This also solves issue #117.
