### PR TITLE
Fix errors when using with Vue 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,49 @@ new Vue({
 })
 ```
 
+### Vue 3 Composition
+
+```js
+import Vue from 'vue'
+import { VueReCaptcha, useRecaptcha } from 'vue-recaptcha-v3'
+
+// For more options see below
+Vue.use(VueReCaptcha, { siteKey: '<site key>', useComposition: true })
+
+new Vue({
+  setup() {
+    const { executeRecaptcha, recaptchaLoaded } = useRecaptcha();
+
+    const recaptcha = async () => {
+      // (optional) Wait until recaptcha has been loaded.
+      await recaptchaLoaded()
+
+      // Execute reCAPTCHA with action "login".
+      const token = await executeRecaptcha('login')
+    }
+
+    return {
+      recaptcha,
+    }
+  },
+  template: '<button @click="recaptcha">Execute recaptcha</button>'
+})
+```
+
+### TypeScript + Vue 3
+To get type suggestions for instance variables (this is not needed for composition API), create a new file called `vue-recaptcha-shims.d.ts` and put the following inside it:
+```ts
+import { ReCaptchaInstance } from 'recaptcha-v3';
+
+declare module '@vue/runtime-core' {
+  interface ComponentCustomProperties {
+    $recaptcha: (action: string) => Promise<string>;
+    $recaptchaLoaded: () => Promise<boolean>;
+    $recaptchaInstance: ReCaptchaInstance;
+  }
+}
+```
+
 ## Options
 This plugin offers optional options to configure the behavior of some parts.
 
@@ -80,4 +123,4 @@ recaptcha.hideBadge()
 
 // Show reCAPTCHA badge:
 recaptcha.showBadge()
-```  
+```

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ createApp(component)
 ```
 
 ### TypeScript + Vue 3
-To get type suggestions for instance variables (this is not needed for composition API), create a new file called `vue-recaptcha-shims.d.ts` and put the following inside it:
+To get type suggestions for instance variables (this is not needed for composition API), create a new file called `shims-vue-recaptcha-v3.d.ts` and put the following inside it:
 ```ts
 import { ReCaptchaInstance } from 'recaptcha-v3'
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,12 @@ new Vue({
 ### Vue 3 Composition
 
 ```js
-import Vue from 'vue'
+import { createApp } from 'vue'
 import { VueReCaptcha, useRecaptcha } from 'vue-recaptcha-v3'
 
-// For more options see below
-Vue.use(VueReCaptcha, { siteKey: '<site key>', useComposition: true })
-
-new Vue({
+const component = {
   setup() {
-    const { executeRecaptcha, recaptchaLoaded } = useRecaptcha();
+    const { executeRecaptcha, recaptchaLoaded } = useRecaptcha()
 
     const recaptcha = async () => {
       // (optional) Wait until recaptcha has been loaded.
@@ -62,26 +59,31 @@ new Vue({
 
       // Execute reCAPTCHA with action "login".
       const token = await executeRecaptcha('login')
+
+      // Do stuff with the received token.
     }
 
     return {
-      recaptcha,
+      recaptcha
     }
   },
   template: '<button @click="recaptcha">Execute recaptcha</button>'
-})
+}
+
+createApp(component)
+  .use(VueReCaptcha, { siteKey: '<site key>' })
 ```
 
 ### TypeScript + Vue 3
 To get type suggestions for instance variables (this is not needed for composition API), create a new file called `vue-recaptcha-shims.d.ts` and put the following inside it:
 ```ts
-import { ReCaptchaInstance } from 'recaptcha-v3';
+import { ReCaptchaInstance } from 'recaptcha-v3'
 
 declare module '@vue/runtime-core' {
   interface ComponentCustomProperties {
-    $recaptcha: (action: string) => Promise<string>;
-    $recaptchaLoaded: () => Promise<boolean>;
-    $recaptchaInstance: ReCaptchaInstance;
+    $recaptcha: (action: string) => Promise<string>
+    $recaptchaLoaded: () => Promise<boolean>
+    $recaptchaInstance: ReCaptchaInstance
   }
 }
 ```

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -14,8 +14,8 @@ const compoent = {
     }
   },
   template: '<button @click="recaptcha">Execute recaptcha</button>'
-};
+}
 
 createApp(compoent)
   .use(VueReCaptcha, { siteKey: '6LfC6HgUAAAAAEtG92bYRzwYkczElxq7WkCoG4Ob' })
-  .mount('#inject');
+  .mount('#inject')

--- a/demo/src/index.ts
+++ b/demo/src/index.ts
@@ -1,9 +1,7 @@
-import Vue from 'vue'
+import { createApp } from 'vue'
 import { VueReCaptcha } from '../../src/ReCaptchaVuePlugin'
 
-Vue.use(VueReCaptcha, { siteKey: '6LfC6HgUAAAAAEtG92bYRzwYkczElxq7WkCoG4Ob' })
-
-new Vue({
+const compoent = {
   methods: {
     recaptcha () {
       console.log('recaptcha clicked')
@@ -16,4 +14,8 @@ new Vue({
     }
   },
   template: '<button @click="recaptcha">Execute recaptcha</button>'
-}).$mount('#inject')
+};
+
+createApp(compoent)
+  .use(VueReCaptcha, { siteKey: '6LfC6HgUAAAAAEtG92bYRzwYkczElxq7WkCoG4Ob' })
+  .mount('#inject');

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -8,7 +8,7 @@
     "declaration": true,
     "removeComments": true,
     "lib": [
-      "es6",
+      "esnext",
       "dom"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -43,12 +43,12 @@
     "html-webpack-plugin": "^4.5.0",
     "ts-loader": "^8.0.4",
     "typescript": "^4.0.3",
-    "vue": "^2.6.12",
+    "vue": "^3.0.0",
     "webpack": "^4.44.2",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"
   },
   "peerDependencies": {
-    "vue": "^2.6.12"
+    "vue": "^3.0.0"
   }
 }

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -21,8 +21,8 @@ export const VueReCaptcha = {
     app.config.globalProperties.$recaptchaLoaded = recaptchaLoaded(isLoaded)
 
     initializeReCaptcha(options).then((wrapper) => {
-      instance.value = wrapper
       isLoaded.value = true
+      instance.value = wrapper
 
       app.config.globalProperties.$recaptcha = recaptcha(instance)
       app.config.globalProperties.$recaptchaInstance = instance

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -6,11 +6,11 @@ const VueReCaptchaInjectKey: InjectionKey<IReCaptchaComposition> = Symbol('VueRe
 
 interface IGlobalConfig {
   loadedWaiters: Array<({resolve: (resolve: boolean) => void, reject: (reject: Error) => void})>
-  error: Error | undefined
+  error: Error | null
 }
 const globalConfig: IGlobalConfig = {
   loadedWaiters: [],
-  error: undefined
+  error: null
 }
 
 export const VueReCaptcha = {

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -5,14 +5,12 @@ import { IReCaptchaOptions } from './IReCaptchaOptions'
 const VueReCaptchaInjectKey: InjectionKey<IReCaptchaComposition> = Symbol('VueReCaptchaInjectKey')
 
 const globalConfig = {
-  options: undefined as IReCaptchaOptions,
   loadedWaiters: [] as Array<({resolve: (resolve: boolean) => void, reject: (reject: Error) => void})>,
   error: undefined as Error | undefined
 }
 
 export const VueReCaptcha = {
   install (app: App, options: IReCaptchaOptions) {
-    globalConfig.options = options
     const isLoaded = ref(false)
     const instance: Ref<ReCaptchaInstance | undefined> = ref(undefined)
 

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -4,9 +4,13 @@ import { IReCaptchaOptions } from './IReCaptchaOptions'
 
 const VueReCaptchaInjectKey: InjectionKey<IReCaptchaComposition> = Symbol('VueReCaptchaInjectKey')
 
-const globalConfig = {
-  loadedWaiters: [] as Array<({resolve: (resolve: boolean) => void, reject: (reject: Error) => void})>,
-  error: undefined as Error | undefined
+interface IGlobalConfig {
+  loadedWaiters: Array<({resolve: (resolve: boolean) => void, reject: (reject: Error) => void})>
+  error: Error | undefined
+}
+const globalConfig: IGlobalConfig = {
+  loadedWaiters: [],
+  error: undefined
 }
 
 export const VueReCaptcha = {

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -16,13 +16,13 @@ export const VueReCaptcha = {
     const isLoaded = ref(false)
     const instance: Ref<ReCaptchaInstance | undefined> = ref(undefined)
 
-    app.config.globalProperties.$recaptchaLoaded = recaptchaLoaded
+    app.config.globalProperties.$recaptchaLoaded = recaptchaLoaded(isLoaded)
 
     initializeReCaptcha(options).then((wrapper) => {
       instance.value = wrapper
       isLoaded.value = true
 
-      app.config.globalProperties.$recaptcha = recaptcha
+      app.config.globalProperties.$recaptcha = recaptcha(instance)
       app.config.globalProperties.$recaptchaInstance = instance
 
       globalConfig.loadedWaiters.forEach((v) => v.resolve(true))

--- a/src/ReCaptchaVuePlugin.ts
+++ b/src/ReCaptchaVuePlugin.ts
@@ -33,7 +33,7 @@ export const VueReCaptcha = {
       globalConfig.loadedWaiters.forEach((v) => v.reject(error))
     })
 
-    provide(VueReCaptchaInjectKey, {
+    app.provide(VueReCaptchaInjectKey, {
       instance,
       isLoaded,
       executeRecaptcha: recaptcha(instance),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "declaration": true,
     "removeComments": true,
     "lib": [
-      "es6",
+      "esnext",
       "dom"
     ]
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,6 +9,11 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
+"@babel/helper-validator-identifier@^7.10.4":
+  version "7.10.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
+  integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
+
 "@babel/highlight@^7.0.0":
   version "7.5.0"
   resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.5.0.tgz#56d11312bd9248fa619591d02472be6e8cb32540"
@@ -185,6 +190,54 @@
   integrity sha512-qC8Olwz5ZyMTZrh4Wl3K4U6tfms0R/mzU4/5W3XeUZptVraGVmbptJbn6h2Ey6Rb3hOs3zWoAUebZk8t47KGiQ==
   dependencies:
     eslint-visitor-keys "^1.1.0"
+
+"@vue/compiler-core@3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-rc.5.tgz#dd4f1816fcae34a81bc60e584f97993cad284d54"
+  integrity sha512-dNz5AObEYg0Oglw3emIsBhTAOVfObrfxDaAzR0UTRDDq+Ohfr6KTSaVQAH88Ym+oa08ZlLZBFc6ARe9doAOIxg==
+  dependencies:
+    "@babel/parser" "^7.10.4"
+    "@babel/types" "^7.10.4"
+    "@vue/shared" "3.0.0-rc.5"
+    estree-walker "^2.0.1"
+    source-map "^0.6.1"
+
+"@vue/compiler-dom@3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-rc.5.tgz#83905e8601123a3654b90fbd80708a16530ce21a"
+  integrity sha512-z8n+R1GhFnWuKURLYxfVSEfP7nSNM91qteobxwys55fhlZZuReouMnUwgrn+ois/IL6RdFlT9H+n4+N6yLrdJA==
+  dependencies:
+    "@vue/compiler-core" "3.0.0-rc.5"
+    "@vue/shared" "3.0.0-rc.5"
+
+"@vue/reactivity@3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-rc.5.tgz#45cff8d839d7ad130b1e499239090050fdecff13"
+  integrity sha512-oe9C+1jtWUdYL/iNc0OPWbwgOk2rOW2uQ+exx3I6Jo6PKOmnAiPkMElalf9vRnO53rnUphVecMp8BlTJvcNgDw==
+  dependencies:
+    "@vue/shared" "3.0.0-rc.5"
+
+"@vue/runtime-core@3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-rc.5.tgz#dd59af3a5fc089d1cdc05a657320c0dc17e5c362"
+  integrity sha512-MRIWreFigxdRuI2moFociUL5rVBfgYPrT7rWfQ0XfOyW46b+AiuCJyZvgbsRXwkAERfW1Tb/mY5forYjX2thOg==
+  dependencies:
+    "@vue/reactivity" "3.0.0-rc.5"
+    "@vue/shared" "3.0.0-rc.5"
+
+"@vue/runtime-dom@3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-rc.5.tgz#2fd75a1f29b23abf0ffe5ccdedabda11721c5b5b"
+  integrity sha512-0jwpO3MBqMToq7qC816Z8Y6G8aN4ZKbv7MupgRaepzxhiK0sXcjLQmOATP3g/NyX52UCBJS4wAwsxidqGnAabA==
+  dependencies:
+    "@vue/runtime-core" "3.0.0-rc.5"
+    "@vue/shared" "3.0.0-rc.5"
+    csstype "^2.6.8"
+
+"@vue/shared@3.0.0-rc.5":
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-rc.5.tgz#cea2378e3e37363ddc1f5dd158edc9c9b5b3fff0"
+  integrity sha512-ZhcgGzBpp+pUzisZgQpM4ctIGgLpYjBj7/rZfbhEPxFHF/BuTV2jmhXvAl8aF9xDAejIcw85xCy92gDSwKtPag==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1199,6 +1252,11 @@ css-what@2.1:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.3.tgz#a6d7604573365fe74686c3f311c56513d88285f2"
   integrity sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg==
+
+csstype@^2.6.8:
+  version "2.6.13"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.13.tgz#a6893015b90e84dd6e85d0e3b442a1e84f2dbe0f"
+  integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -4806,6 +4864,11 @@ to-arraybuffer@^1.0.0:
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
 
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
+  integrity sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
 to-object-path@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/to-object-path/-/to-object-path-0.3.0.tgz#297588b7b0e7e0ac08e04e672f85c1f4999e17af"
@@ -5061,10 +5124,14 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
-vue@^2.6.12:
-  version "2.6.12"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.12.tgz#f5ebd4fa6bd2869403e29a896aed4904456c9123"
-  integrity sha512-uhmLFETqPPNyuLLbsKz6ioJ4q7AZHzD8ZVFNATNyICSZouqP2Sz0rotWQC8UNBF6VGSCs5abnKJoStA6JbCbfg==
+vue@^3.0.0-rc.5:
+  version "3.0.0-rc.5"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-rc.5.tgz#973175d45a892b3bd23ef5de7faa4add9c66275f"
+  integrity sha512-8t8Y4sHMBGD5iLZ7JfBGmKBJlzesPoL+/nW9EV8s+4LwnKC4rGlRp+Lj2rcign4iQaj0GFaL7DrQ8IoOfVX6+w==
+  dependencies:
+    "@vue/compiler-dom" "3.0.0-rc.5"
+    "@vue/runtime-dom" "3.0.0-rc.5"
+    "@vue/shared" "3.0.0-rc.5"
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,20 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@babel/parser@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
+  integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
+
+"@babel/types@^7.11.5":
+  version "7.11.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
+  integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
 "@eslint/eslintrc@^0.1.3":
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
@@ -191,53 +205,53 @@
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-"@vue/compiler-core@3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0-rc.5.tgz#dd4f1816fcae34a81bc60e584f97993cad284d54"
-  integrity sha512-dNz5AObEYg0Oglw3emIsBhTAOVfObrfxDaAzR0UTRDDq+Ohfr6KTSaVQAH88Ym+oa08ZlLZBFc6ARe9doAOIxg==
+"@vue/compiler-core@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-core/-/compiler-core-3.0.0.tgz#25e4f079cf6c39f83bad23700f814c619105a0f2"
+  integrity sha512-XqPC7vdv4rFE77S71oCHmT1K4Ks3WE2Gi6Lr4B5wn0Idmp+NyQQBUHsCNieMDRiEpgtJrw+yOHslrsV0AfAsfQ==
   dependencies:
-    "@babel/parser" "^7.10.4"
-    "@babel/types" "^7.10.4"
-    "@vue/shared" "3.0.0-rc.5"
+    "@babel/parser" "^7.11.5"
+    "@babel/types" "^7.11.5"
+    "@vue/shared" "3.0.0"
     estree-walker "^2.0.1"
     source-map "^0.6.1"
 
-"@vue/compiler-dom@3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0-rc.5.tgz#83905e8601123a3654b90fbd80708a16530ce21a"
-  integrity sha512-z8n+R1GhFnWuKURLYxfVSEfP7nSNM91qteobxwys55fhlZZuReouMnUwgrn+ois/IL6RdFlT9H+n4+N6yLrdJA==
+"@vue/compiler-dom@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/compiler-dom/-/compiler-dom-3.0.0.tgz#4cbb48fcf1f852daef2babcf9953b681ac463526"
+  integrity sha512-ukDEGOP8P7lCPyStuM3F2iD5w2QPgUu2xwCW2XNeqPjFKIlR2xMsWjy4raI/cLjN6W16GtlMFaZdK8tLj5PRog==
   dependencies:
-    "@vue/compiler-core" "3.0.0-rc.5"
-    "@vue/shared" "3.0.0-rc.5"
+    "@vue/compiler-core" "3.0.0"
+    "@vue/shared" "3.0.0"
 
-"@vue/reactivity@3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0-rc.5.tgz#45cff8d839d7ad130b1e499239090050fdecff13"
-  integrity sha512-oe9C+1jtWUdYL/iNc0OPWbwgOk2rOW2uQ+exx3I6Jo6PKOmnAiPkMElalf9vRnO53rnUphVecMp8BlTJvcNgDw==
+"@vue/reactivity@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.0.0.tgz#fd15632a608650ce2a969c721787e27e2c80aa6b"
+  integrity sha512-mEGkztGQrAPZRhV7C6PorrpT3+NtuA4dY2QjMzzrW31noKhssWTajRZTwpLF39NBRrF5UU6cp9+1I0FfavMgEQ==
   dependencies:
-    "@vue/shared" "3.0.0-rc.5"
+    "@vue/shared" "3.0.0"
 
-"@vue/runtime-core@3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0-rc.5.tgz#dd59af3a5fc089d1cdc05a657320c0dc17e5c362"
-  integrity sha512-MRIWreFigxdRuI2moFociUL5rVBfgYPrT7rWfQ0XfOyW46b+AiuCJyZvgbsRXwkAERfW1Tb/mY5forYjX2thOg==
+"@vue/runtime-core@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.0.0.tgz#480febf1bfe32798b6abbd71a88f8e8b473a51c2"
+  integrity sha512-3ABMLeA0ZbeVNLbGGLXr+pNUwqXILOqz8WCVGfDWwQb+jW114Cm8djOHVVDoqdvRETQvDf8yHSUmpKHZpQuTkA==
   dependencies:
-    "@vue/reactivity" "3.0.0-rc.5"
-    "@vue/shared" "3.0.0-rc.5"
+    "@vue/reactivity" "3.0.0"
+    "@vue/shared" "3.0.0"
 
-"@vue/runtime-dom@3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0-rc.5.tgz#2fd75a1f29b23abf0ffe5ccdedabda11721c5b5b"
-  integrity sha512-0jwpO3MBqMToq7qC816Z8Y6G8aN4ZKbv7MupgRaepzxhiK0sXcjLQmOATP3g/NyX52UCBJS4wAwsxidqGnAabA==
+"@vue/runtime-dom@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.0.tgz#e0d1f7c7e22e1318696014cc3501e06b288c2e11"
+  integrity sha512-f312n5w9gK6mVvkDSj6/Xnot1XjlKXzFBYybmoy6ahAVC8ExbQ+LOWti1IZM/adU8VMNdKaw7Q53Hxz3y5jX8g==
   dependencies:
-    "@vue/runtime-core" "3.0.0-rc.5"
-    "@vue/shared" "3.0.0-rc.5"
+    "@vue/runtime-core" "3.0.0"
+    "@vue/shared" "3.0.0"
     csstype "^2.6.8"
 
-"@vue/shared@3.0.0-rc.5":
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0-rc.5.tgz#cea2378e3e37363ddc1f5dd158edc9c9b5b3fff0"
-  integrity sha512-ZhcgGzBpp+pUzisZgQpM4ctIGgLpYjBj7/rZfbhEPxFHF/BuTV2jmhXvAl8aF9xDAejIcw85xCy92gDSwKtPag==
+"@vue/shared@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/shared/-/shared-3.0.0.tgz#ec089236629ecc0f10346b92f101ff4339169f1a"
+  integrity sha512-4XWL/avABGxU2E2ZF1eZq3Tj7fvksCMssDZUHOykBIMmh5d+KcAnQMC5XHMhtnA0NAvktYsA2YpdsVwVmhWzvA==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -1858,6 +1872,11 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+
+estree-walker@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.1.tgz#f8e030fb21cefa183b44b7ad516b747434e7a3e0"
+  integrity sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -5124,14 +5143,14 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.0.tgz#bd76d6a23323e2ca8ffa12028dc04559c75f9019"
   integrity sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==
 
-vue@^3.0.0-rc.5:
-  version "3.0.0-rc.5"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0-rc.5.tgz#973175d45a892b3bd23ef5de7faa4add9c66275f"
-  integrity sha512-8t8Y4sHMBGD5iLZ7JfBGmKBJlzesPoL+/nW9EV8s+4LwnKC4rGlRp+Lj2rcign4iQaj0GFaL7DrQ8IoOfVX6+w==
+vue@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.0.0.tgz#cfb5df5c34efce319b113a1667d12b74dcfd9c90"
+  integrity sha512-ZMrAARZ32sGIaYKr7Fk2GZEBh/VhulSrGxcGBiAvbN4fhjl3tuJyNFbbbLFqGjndbLoBW66I2ECq8ICdvkKdJw==
   dependencies:
-    "@vue/compiler-dom" "3.0.0-rc.5"
-    "@vue/runtime-dom" "3.0.0-rc.5"
-    "@vue/shared" "3.0.0-rc.5"
+    "@vue/compiler-dom" "3.0.0"
+    "@vue/runtime-dom" "3.0.0"
+    "@vue/shared" "3.0.0"
 
 watchpack-chokidar2@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### Summary

This closes #217 

- Updated plugin structure to use install method to fix TS error mentioned in the issue
- Added composition helper function, `useReCaptcha`
- Upgraded to `vue@^3.0.0-rc.5`

#### Resources

- https://github.com/vuejs/vuex/blob/4.0/src/store.js
- https://github.com/vuejs/vue-router-next/blob/910634e659be83eabf65b2215e201cdea1c02761/src/router.ts
- https://learnvue.co/2020/03/designing-vue3-plugins-using-provide-and-inject/
- https://vuejs.org/v2/guide/plugins.html

#### Other Comments

- First time writing a plugin, so I might have over-restructured the main file
- `README.md` might have some lint errors in new example code, your code style is different than mine but I tried to match it, so let me know if I missed anything
- Couldn't get the demo application working, webpack was complaining about not being able to find the "vue" module, but I did do manual testing on my personal project and both the new `useReCaptcha` and old usage were working.